### PR TITLE
Try to always show a month with events in Course#show.

### DIFF
--- a/app/services/paginate_events_by_month.rb
+++ b/app/services/paginate_events_by_month.rb
@@ -1,17 +1,49 @@
 class PaginateEventsByMonth
-  attr_reader :current_month, :events
+  attr_reader :current_month
 
   def initialize(events, day_in_month)
-    day_in_month ||= Time.current
-    @current_month = day_in_month.to_time.in_time_zone.beginning_of_month
-    @events = events.where(start_at: @current_month..@current_month.end_of_month)
+    @all_events = events.order(:start_at)
+
+    if day_in_month.blank? && events_for_month.empty? && all_events.any?
+      @current_month = next_month_with_event || last_month_with_event
+    else
+      day_in_month ||= Time.current
+      @current_month = day_in_month.to_time.in_time_zone.beginning_of_month
+    end
   end
 
   def next_month
-    @current_month + 1.month
+    current_month + 1.month
   end
 
   def previous_month
-    @current_month - 1.month
+    current_month - 1.month
+  end
+
+  def events
+    @events ||= events_for_month(current_month)
+  end
+
+  private
+
+  attr_reader :all_events
+
+  def month_for(day_in_month)
+    day_in_month.to_time.in_time_zone.beginning_of_month
+  end
+
+  def events_for_month(month = Time.current)
+    full_month = month.beginning_of_month..month.end_of_month
+    all_events.where(start_at: full_month)
+  end
+
+  def next_month_with_event
+    event = all_events.where('start_at > ?', Time.current).first
+    event && event.start_at.beginning_of_month
+  end
+
+  def last_month_with_event
+    event = all_events.where('start_at < ?', Time.current).last
+    event && event.start_at.beginning_of_month
   end
 end

--- a/spec/services/paginate_events_by_month_spec.rb
+++ b/spec/services/paginate_events_by_month_spec.rb
@@ -8,14 +8,45 @@ describe PaginateEventsByMonth do
   after { Timecop.return }
 
   context "without given month" do
-    let!(:event_from_december) { create(:event, start_at: "2014-12-01 01:00:00") }
-    let!(:event_from_january) { create(:event, start_at: "2015-01-01 01:00:00") }
     let(:pagination) { PaginateEventsByMonth.new(Event.all, nil) }
 
-    it { expect(pagination.events).to eq([event_from_december]) }
-    it { expect(pagination.current_month).to eq("2014-12-01 00:00:00".in_time_zone) }
-    it { expect(pagination.next_month).to eq("2015-01-01 00:00:00".in_time_zone) }
-    it { expect(pagination.previous_month).to eq("2014-11-01 00:00:00".in_time_zone) }
+    context "with events in current month" do
+      let!(:event_from_december) { create(:event, start_at: "2014-12-01 01:00:00") }
+      let!(:event_from_january) { create(:event, start_at: "2015-01-01 01:00:00") }
+
+      it { expect(pagination.events).to eq([event_from_december]) }
+      it { expect(pagination.current_month).to eq("2014-12-01 00:00:00".in_time_zone) }
+      it { expect(pagination.next_month).to eq("2015-01-01 00:00:00".in_time_zone) }
+      it { expect(pagination.previous_month).to eq("2014-11-01 00:00:00".in_time_zone) }
+    end
+
+    context "with no events in current month" do
+      context "with events in the future" do
+        let!(:event_from_january) { create(:event, start_at: "2015-01-01 01:00:00") }
+
+        it { expect(pagination.events).to eq([event_from_january]) }
+        it { expect(pagination.current_month).to eq("2015-01-01 00:00:00".in_time_zone) }
+        it { expect(pagination.next_month).to eq("2015-02-01 00:00:00".in_time_zone) }
+        it { expect(pagination.previous_month).to eq("2014-12-01 00:00:00".in_time_zone) }
+      end
+
+      context "with no events in the future, but events in the past" do
+        let!(:event_from_january) { create(:event, start_at: "2014-01-01 01:00:00") }
+        let!(:event_from_november) { create(:event, start_at: "2014-11-01 01:00:00") }
+
+        it { expect(pagination.events).to eq([event_from_november]) }
+        it { expect(pagination.current_month).to eq("2014-11-01 00:00:00".in_time_zone) }
+        it { expect(pagination.next_month).to eq("2014-12-01 00:00:00".in_time_zone) }
+        it { expect(pagination.previous_month).to eq("2014-10-01 00:00:00".in_time_zone) }
+      end
+
+      context "with no events at all" do
+        it { expect(pagination.events).to be_blank }
+        it { expect(pagination.current_month).to eq("2014-12-01 00:00:00".in_time_zone) }
+        it { expect(pagination.next_month).to eq("2015-01-01 00:00:00".in_time_zone) }
+        it { expect(pagination.previous_month).to eq("2014-11-01 00:00:00".in_time_zone) }
+      end
+    end
   end
 
   context "with given month" do


### PR DESCRIPTION
- If the course has events in the given month, the given month is displayed.
- If it doesn’t, we try to find an event in the future.
- If we don’t have an event in the future, we look for an event in the past.
- If we can’t find events at all, show current month.
