### PR TITLE
Fixing student's header margin

### DIFF
--- a/app/assets/stylesheets/pages/_student.scss
+++ b/app/assets/stylesheets/pages/_student.scss
@@ -343,10 +343,6 @@
     }
   }
 
-  .page-header {
-    margin-bottom: 0;
-  }
-
   .back__button {
     white-space: nowrap;
   }


### PR DESCRIPTION
@lunks, the only other interface bug I found is when accessing the first or
last event's journal; it breaks the layout. It occurs in the teacher's
interface too.

@ltartari, why was the margin-bottom zeroed in the student's interface?
