### PR TITLE
Avoid empty navigation breaking the layout.

### DIFF
--- a/app/assets/stylesheets/pages/_diary.scss
+++ b/app/assets/stylesheets/pages/_diary.scss
@@ -387,6 +387,8 @@
 }
 
 .summary__tasks {
+  min-height: 1em;
+
   &.previous__event__tasks {
     padding-left: 1em;
 


### PR DESCRIPTION
Empty columns would break the layout. This is simple solved by adding a default `min-height: 1em;` to them.
