### PR TITLE
Improve contrast for menu links.

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -694,7 +694,7 @@ $off-canvas-bg: darken($primary-color, 10%);
 
 // Off Canvas Menu List Variables
 // $off-canvas-label-padding: 0.3rem rem-calc(15);
-$off-canvas-label-color: $dark-grey-color;
+$off-canvas-label-color: $white;
 // $off-canvas-label-text-transform: uppercase;
 // $off-canvas-label-font-weight: $font-weight-bold;
 $off-canvas-label-bg: rgba(255, 255, 255, .05);
@@ -702,11 +702,11 @@ $off-canvas-label-bg: rgba(255, 255, 255, .05);
 // $off-canvas-label-border-bottom: none;
 // $off-canvas-label-margin:0;
 // $off-canvas-link-padding: rem-calc(10, 15);
-$off-canvas-link-color: $dark-grey-color;
+$off-canvas-link-color: $white;
 // $off-canvas-link-border-bottom: 1px solid scale-color($off-canvas-bg, $lightness: -25%);
 
 // Off Canvas Menu Icon Variables
-$tabbar-menu-icon-color: $dark-grey-color;
+$tabbar-menu-icon-color: $white;
 $tabbar-menu-icon-hover: $dark-grey-color;
 
 // $tabbar-menu-icon-text-indent: rem-calc(35);
@@ -1206,9 +1206,9 @@ $topbar-dropdown-toggle-color: $black;
 // $topbar-dropdown-toggle-alpha: 0.4;
 
 // Set the link colors and styles for top-level nav
-$topbar-link-color: $dark-grey-color;
-$topbar-link-color-hover: $white;
-$topbar-link-color-active: $white;
+$topbar-link-color: $white;
+$topbar-link-color-hover: darken($white, 20%);
+$topbar-link-color-active: $secondary-color;
 $topbar-link-color-active-hover: $primary-color;
 // $topbar-link-weight: $font-weight-normal;
 $topbar-link-font-size: rem-calc(15);

--- a/app/views/application/_menu.html.slim
+++ b/app/views/application/_menu.html.slim
@@ -26,7 +26,7 @@ aside.right-off-canvas-menu
     li
       = yield
   ul.off-canvas-list
-    li
+    li.active
       label.first
         | {{currentUser().name}}
     li

--- a/app/views/layouts/teacher.html.slim
+++ b/app/views/layouts/teacher.html.slim
@@ -18,12 +18,16 @@ html lang="pt" ng-app="DunnoApp"
     .off-canvas-wrap data-offcanvas=''
       .inner-wrap
         = render layout: 'application/menu' do
+          / TODO: add active class whenever inside one of this contexts
           li
-            a href="#events" Aulas
+            a href="#events"
+              | Aulas
           li
-            a href="#courses" Disciplinas
+            a href="#courses"
+              | Disciplinas
           li
-            a href="#catalog" Catálogo
+            a href="#catalog"
+              | Catálogo
 
         .content ng-view="" cg-busy="wholePageLoading" ng-class="controller"
 


### PR DESCRIPTION
Header menu now looks like this:
![screen shot 2015-06-02 at 5 11 33 pm](https://cloud.githubusercontent.com/assets/114248/7945975/7672eca4-094a-11e5-846a-2255aeff9a6e.png)

@mrodrigues @lunks we still need to address the "active" class on the <LI> elements as commented on line 21 of app/views/layouts/teacher.html.slim. 
