### PR TITLE
Clean up long copy on events page.

### DIFF
--- a/app/assets/stylesheets/pages/_events.scss
+++ b/app/assets/stylesheets/pages/_events.scss
@@ -123,8 +123,6 @@
 
             .image {
               display: none;
-              vertical-align: top;
-              width: 10%;
             }
 
             span {


### PR DESCRIPTION
This is just a quick fix for long strings breaking the layout at the events page.
