### PR TITLE
Reverts the “Voltar” button to the old behaviour.

### DIFF
--- a/app/assets/templates/teacher/events/show.html.slim
+++ b/app/assets/templates/teacher/events/show.html.slim
@@ -1,7 +1,7 @@
 header.page__header ng-class="'scheme-' + event.course.order"
   .row
     .small-3.columns
-      a.back__button.button.small.transparent.secondary ui-sref="^"
+      a.back__button.button.small.transparent.secondary ui-sref="courses.show.calendar({course: event.course, month: event.start_at})"
         i.icon.icon-arrow-back>
         span.hide-for-small
           | Voltar
@@ -98,7 +98,7 @@ header.page__header ng-class="'scheme-' + event.course.order"
         .show-for-small.small-1.columns
           a.previous__event.mobile__day__navigation[
             ng-if="!!event.previous.uuid"
-            ui-sref="events.show({ id: event.previous.uuid })"
+            ui-sref="{ id: event.previous.uuid }"
             analytics-on="click"
             analytics-event="Event Navigation"
             analytics-name="previous"
@@ -116,7 +116,7 @@ header.page__header ng-class="'scheme-' + event.course.order"
         .show-for-small.small-1.columns
           a.next__event.mobile__day__navigation[
             ng-if="!!event.next.uuid"
-            ui-sref="events.show({ id: event.next.uuid })"
+            ui-sref="{ id: event.next.uuid }"
             analytics-on="click"
             analytics-event="Event Navigation"
             analytics-name="next"


### PR DESCRIPTION
We can’t use ^ if it’s an abstract state. I tried finding another solution,
but none of them worked. I’m reverting to the old behaviour for now.

cc @mrodrigues
