### PR TITLE
Fix long strings for course events tab.

### DIFF
--- a/app/assets/stylesheets/pages/_course-events.scss
+++ b/app/assets/stylesheets/pages/_course-events.scss
@@ -39,22 +39,34 @@
         color: $dark-grey-color;
       }
     }
+
+    &:after {
+      clear: both;
+      content: ' ';
+      display: block;
+      height: 0;
+      width: 100%;
+    }
   }
 
   .icon-check {
     color: transparent;
+    float: left;
+    margin-right: .5rem;
   }
 
   .topic__item__image {
     @include thumbnail();
     display: inline-block;
-    margin-left: .5rem;
+    margin-right: .5rem;
   }
 
   .topic__item__description {
+    display: block;
     font-size: .875rem;
-    margin: 0 .5rem;
+    margin-left: 1.5rem;
     padding: .25rem;
+    word-break: break-word;
   }
 
   .comment__event__wrapper {

--- a/app/assets/templates/courses/tabs/events.html.slim
+++ b/app/assets/templates/courses/tabs/events.html.slim
@@ -12,7 +12,7 @@
           i.icon.status__icon[
             class="status__icon__{{event.status}}"
             title="{{event.status}}"]
-        .event__content
+        .event__content[class="event__status__{{event.status}}"]
           .no__topics.empty__results ng-if="event.topics.length == 0"
             | Nenhum conteúdo disponível para esse dia.
           .event__items ng-if="event.topics.length != 0"
@@ -21,17 +21,6 @@
               ng-repeat="topic in event.topics"
               ng-if="topic.personal != true"]
               i.icon.icon-check
-              a.topic__item__image[
-                ng-if="!!topic.media"
-                target="_blank"
-                ng-style="{ 'background-image': 'url(' + topic.media.thumbnail + ')' }"
-                ng-href="{{topic.media.url}}"
-                analytics-on="click"
-                analytics-event="Media Clicked"
-                analytics-uuid="{{media.uuid}}"
-                analytics-event-uuid="{{event.uuid}}"
-                analytics-course-name="{{event.course.name}}"
-                analytics-course-uuid="{{event.course.uuid}}"]
               a.topic__item__description[
                 ng-class="{preview: !!topic.media}"
                 ng-if="!!topic.media"
@@ -43,6 +32,8 @@
                 analytics-event-uuid="{{event.uuid}}"
                 analytics-course-name="{{event.course.name}}"
                 analytics-course-uuid="{{event.course.uuid}}"]
+                span.topic__item__image[
+                  ng-style="{ 'background-image': 'url(' + topic.media.thumbnail + ')' }"]
                 | {{topic.description}}
               span.topic__item__description ng-class="{preview: !!topic.media}" ng-if="!topic.media"
                 | {{topic.description}}


### PR DESCRIPTION
Fix long strings breaking the layout at the course events tab, so this:
![screen shot 2015-07-20 at 6 21 51 pm](https://cloud.githubusercontent.com/assets/114248/8787753/3be2434a-2f0c-11e5-8a9f-20ac92e40c29.png)

Will be treated like this:
![screen shot 2015-07-20 at 6 22 21 pm](https://cloud.githubusercontent.com/assets/114248/8787805/8d1c251e-2f0c-11e5-9b31-e413060bb774.png)

@lunks @mrodrigues  /!\ ignore the status icon glued to the date /!\
