### PR TITLE
[WIP] Tour – new tutorial

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require jquery-ui-touch-punch/jquery.ui.touch-punch
 //= require foundation/foundation
 //= require foundation/foundation.dropdown
+//= require foundation/foundation.joyride
 //= require foundation/foundation.reveal
 //= require ng-file-upload-shim
 //= require angular
@@ -42,4 +43,6 @@
 //= require initial.js
 //= require_tree ./angular/
 
-$(function(){ $(document).foundation(); });
+$(function(){
+  $(document).foundation()
+});

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -596,17 +596,17 @@ $input-placeholder-font-color: $medium-grey-color;
 // $include-html-joyride-classes: $include-html-classes;
 
 // Controlling default Joyride styles
-// $joyride-tip-bg: #333;
+$joyride-tip-bg: $white;
 // $joyride-tip-default-width: 300px;
 // $joyride-tip-padding: rem-calc(18 20 24);
-// $joyride-tip-border: solid 1px #555;
-// $joyride-tip-radius: 4px;
+$joyride-tip-border: 0;
+$joyride-tip-radius: $global-radius;
 // $joyride-tip-position-offset: 22px;
 
 // Here, we're setting the tip dont styles
-// $joyride-tip-font-color: #fff;
-// $joyride-tip-font-size: rem-calc(14);
-// $joyride-tip-header-weight: $font-weight-bold;
+$joyride-tip-font-color: $dunno-dark-color;
+$joyride-tip-font-size: rem-calc(16);
+$joyride-tip-header-weight: $font-weight-bold;
 
 // This changes the nub size
 // $joyride-tip-nub-size: 10px;
@@ -617,12 +617,12 @@ $input-placeholder-font-color: $medium-grey-color;
 // $joyride-tip-timer-color: #666;
 
 // This changes up the styles for the close button
-// $joyride-tip-close-color: #777;
-// $joyride-tip-close-size: 24px;
+$joyride-tip-close-color: $medium-grey-color;
+$joyride-tip-close-size: rem-calc(24);
 // $joyride-tip-close-weight: $font-weight-normal;
 
 // When Joyride is filling the screen, we use this style for the bg
-// $joyride-screenfill: rgba(0,0,0,0.5);
+$joyride-screenfill: transparentize($dunno-dark-color, .15);
 
 // Keystrokes
 

--- a/app/assets/stylesheets/themes/_theme.scss
+++ b/app/assets/stylesheets/themes/_theme.scss
@@ -29,3 +29,12 @@
 .right-off-canvas-menu {
   min-height: 100vh;
 }
+
+.joyride-tip-guide {
+  @include radius();
+}
+
+.joyride-expose-wrapper {
+  background-color: transparent;
+  box-shadow: 0 0 0 transparent;
+}

--- a/app/assets/templates/courses/index.html.slim
+++ b/app/assets/templates/courses/index.html.slim
@@ -4,17 +4,16 @@ ui-view
       .small-8.small-offset-2.columns
         h1.main__page__title
           | Disciplinas
-      /
-        .small-2.columns ng-if="currentUser().profile == 'teacher'"
-          a.button.round.rounded.right[href="#courses/new"]
-            | +
+      .small-2.columns ng-if="currentUser().profile == 'teacher'"
+        a.button.round.rounded.right#tour__3[href="#courses/new"]
+          | +
       .page__title__actions.small-2.columns ng-if="currentUser().profile == 'student'"
         a.button.round.rounded.right ui-sref="courses.search"
           | +
   .courses__page
     .row
       / TODO: empty results
-      ul.courses__list.small-block-grid-1.medium-block-grid-2.large-block-grid-3
+      ul#tour__1.courses__list.small-block-grid-1.medium-block-grid-2.large-block-grid-3
         li.course__card ng-repeat="course in courses"
           a.course__card__link[
             ng-attr-id="{{ 'course-' + course.uuid }}"
@@ -39,8 +38,54 @@ ui-view
                   | {{course.class_name}}
               .small-2.columns
                 i.icon.icon-users.course__icon
-    tutorial.tutorial-1[
-      ng-if="tutorialEnabled(1)"
-      on-close="tutorialClosed(1)"]
-      p
-        | Comece entrando em uma de suas disciplinas.
+    .row
+      .small-6.small-centered.columns
+        button.expand.button.radius#start__tour
+          | Iniciar Tour Guiado
+ol.joyride-list data-joyride=""
+  li[
+    data-id='start__tour'
+    data-class='radius'
+    data-text='Me ensine'
+    data-options='tip_location:top; prev_button:false;']
+    h2
+      | Dicas do Dunno!
+    p
+      | Olá e bem vinda(o) às dicas de uso do Dunno.
+    p
+      small
+        | Se já estiver confortável com o Dunno e não precisar mais de ajuda você pode #{link_to 'desabilitar as dicas', '#'}. Elas poderão ser reabilitadas a qualquer momento acessando sua #{link_to 'página de perfil', '#'}.
+  li[
+    data-id='tour__1'
+    data-button='Avançar'
+    data-prev-text='Voltar'
+    data-options="tip_location:top;"]
+    h4
+      | Lista de Disciplinas
+    p
+      | Cada cartão representa uma disciplina cadastrada por você no Dunno.
+  li[
+    data-id='course-b0cce870-5620-49d5-842f-4be5ed67f4c1'
+    data-button='Avançar'
+    data-prev-text='Voltar'
+    data-options="tip_location:right;"]
+    h4
+      | Cartão da Discliplina
+    p
+      | Para visualizar o conteúdo de uma disciplina, pressione o cartão desejado.
+  li[
+    data-id='tour__3'
+    data-button='Usar o Dunno!'
+    data-prev-text='Voltar'
+    data-options="tip_location:left;"]
+    h4
+      | Adicionando Discliplinas
+    p
+      | Para visualizar o conteúdo de uma disciplina, pressione o cartão desejado.
+/
+  javascript:
+    $(document).foundation('joyride', 'start', {
+      expose: true,
+      modal: true,
+      exposed: ['#start__tour', '#tour__1', '#tour__3']
+    });


### PR DESCRIPTION
A POC for new tutorial system using Foundation's Joyride.

This is bigger than expected, so I'll need a lot of help @lunks @mrodrigues 
- [ ] Make BG appear for exposed elements to pop
  For some reason the `.joyride-modal-bg` element keeps getting a `display: none` after starting the joyride plugin (has to be done manually, using the javascript provided at the bottom).
- [ ] Start on first access.
  I believe we'll have to create a directive for this.
- [ ] Save the option to not show again as a preference to the user.
- [ ] Add preference at the edit profile screen.
- [ ] Improve layout
  We'll have to override foundation, since they don't offer variables for everything.
- [ ] Write copy for each step.
  By far this will be the most time consuming task.
- [ ] Show step number
  At each panel we should provide some clear indication of how many steps there'll be shown at the tutorial (can be simple as 1 of 5, 2 of 5 or something more visual like ••···)
- [ ] Animate exposed elements with `pop`.

To preview it, just open the console and type:

```
    $(document).foundation('joyride', 'start', {
      expose: true,
      modal: true,
      exposed: ['#start__tour', '#tour__1', '#tour__3']
    });
```
