### PR TITLE
Fix not being able to extend a weekly schedule time

### DIFF
--- a/app/services/transfer_weekly_schedule.rb
+++ b/app/services/transfer_weekly_schedule.rb
@@ -18,9 +18,9 @@ class TransferWeeklySchedule
 
   def affected_events
     @affected_events ||= old_schedule
-                        .all_occurrences
-                        .map { |occurrence| find_event(occurrence) }
-                        .select(&:present?)
+                         .all_occurrences
+                         .map { |occurrence| find_event(occurrence) }
+                         .select(&:present?)
   end
 
   private
@@ -52,7 +52,7 @@ class TransferWeeklySchedule
   end
 
   def duration
-    @duration ||=  time_to_i(new_weekly_schedule.end_time) - time_to_i(new_weekly_schedule.start_time)
+    @duration ||= time_to_i(new_weekly_schedule.end_time) - time_to_i(new_weekly_schedule.start_time)
   end
 
   def find_event(occurrence)
@@ -75,6 +75,6 @@ class TransferWeeklySchedule
   end
 
   def new_weekly_schedule
-    @new_weekly_schedule ||= WeeklySchedule.new(@attributes.merge(course: course))
+    @new_weekly_schedule ||= WeeklySchedule.new(weekly_schedule.attributes.merge(@attributes))
   end
 end

--- a/spec/services/transfer_weekly_schedule_spec.rb
+++ b/spec/services/transfer_weekly_schedule_spec.rb
@@ -21,12 +21,18 @@ describe TransferWeeklySchedule do
       it { expect(service).to be_valid }
     end
 
+    context "overlapping with itself" do
+      let(:attributes) { { end_time: '12:00' } }
+
+      it { expect(service).to be_valid }
+    end
+
     context "with invalid attributes in the :to param" do
-      let(:attributes) { {} }
+      let(:attributes) { { start_time: '' } }
 
       it do
         expect(service).not_to be_valid
-        expect(service.errors.keys).to eq([:weekday, :start_time, :end_time])
+        expect(service.errors.keys).to eq([:start_time])
         expect { service.transfer! }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end


### PR DESCRIPTION
Fixes #812
@lunks, it was failing when trying to update a weekly schedule to a time where it'd overlap itself.
