### PR TITLE
Remove draft events for students on calendar and events tabs

### DIFF
--- a/app/assets/javascripts/angular/apps/teachers/controllers/CourseCtrl.js.coffee.erb
+++ b/app/assets/javascripts/angular/apps/teachers/controllers/CourseCtrl.js.coffee.erb
@@ -17,7 +17,6 @@ CourseCtrl = ($scope, $location, $stateParams, $state, $modal, Course, Utils, Da
 
   $scope.eventClass = (event) ->
     klass = DateUtils.locationInTime(event.start_at)
-    klass += " has-tooltip" unless $scope.canAccessEvent(event)
     klass
 
   $scope.fetch = (month) ->
@@ -53,20 +52,30 @@ CourseCtrl = ($scope, $location, $stateParams, $state, $modal, Course, Utils, Da
   $scope.canAccessEvent = (event) ->
     event.status == 'published' || $scope.course.user_role == 'teacher'
 
-  $scope.tooltipMessage = (event) ->
-    return undefined if $scope.canAccessEvent(event)
-    if event.formatted_status == 'canceled'
-      'Esta aula foi cancelada'
-    else
-      'Esta aula ainda está vazia'
-
   $scope.translatedStatus = (event) ->
-    if event.formatted_status == 'canceled'
+    if $scope.isCanceled(event)
       'Cancelada'
-    else if event.formatted_status == 'published' || event.formatted_status == 'happened'
+    else if $scope.isPublished(event)
       'Publicada'
-    else if event.formatted_status == 'empty' || event.formatted_status == 'draft'
+    else if $scope.isDraft(event)
       'Rascunho'
+
+  $scope.isCanceled = (event) ->
+    event.formatted_status == 'canceled'
+
+  $scope.isPublished = (event) ->
+    event.formatted_status == 'published' ||
+    event.formatted_status == 'happened'
+
+  $scope.isDraft = (event) ->
+    event.formatted_status == 'draft' ||
+    event.formatted_status == 'empty'
+
+  $scope.isTeacher = (course) ->
+    course.user_role == 'teacher'
+
+  $scope.isStudent = (course) ->
+    course.user_role != 'teacher'
 
   $scope.openEditCourseForm = ->
     $modal.open

--- a/app/assets/stylesheets/pages/_course-calendar.scss
+++ b/app/assets/stylesheets/pages/_course-calendar.scss
@@ -140,7 +140,6 @@
 }
 
 .date__status {
-  color: $dunno-green-color;
   font-size: .875rem;
   font-style: normal;
   margin-left: auto;
@@ -154,12 +153,11 @@
     text-align: right;
   }
 
-  &.draft,
-  &.empty {
-    color: $dunno-dark-color;
+  &.published {
+    color: $dunno-green-color;
   }
 
-  &.cancelled {
+  &.canceled {
     color: $red-color;
   }
 }

--- a/app/assets/templates/courses/tabs/calendar.html.slim
+++ b/app/assets/templates/courses/tabs/calendar.html.slim
@@ -6,7 +6,7 @@
           a.button.transparent.expand.primary.small ui-sref=".schedule"
             strong
               | Cronograma
-        .small-12.columns.dates__header__navigation ng-class="{'medium-8': course.user_role == 'teacher'}"
+        .small-12.columns.dates__header__navigation ng-class="{'medium-8': isTeacher(course)}"
           a.button.transparent.secondary.small.dates__header__previous-month.left ui-sref="{month: course.previous_month}"
             i.icon.icon-chevron-left
             span<
@@ -20,15 +20,12 @@
     .empty__results.no__events ng-if="!course.events || course.events.length == 0"
       p
         | Até o momento nenhuma aula foi criada neste mês.
-
     .calendar__dates
       .calendar__date ng-repeat="event in course.events | orderBy:'start_at'"
         a.calendar__date__link[
           ng-attr-id="{{'event-' + event.uuid}}"
           ng-click="goToEvent(event)"
           ng-class="eventClass(event)"
-          ng-attr-tooltip="{{tooltipMessage(event)}}"
-          tooltip-animation="false"
           analytics-on="click"
           analytics-event="Event Accessed via Course"
           analytics-uuid="{{event.uuid}}"
@@ -45,5 +42,6 @@
           span.date__classroom
             span ng-if="event.classroom"
               | {{event.classroom}}
-          span.date__status ng-class="{cancelled: event.formatted_status == 'canceled', draft: (event.formatted_status == 'empty') || (event.formatted_status == 'draft')}"
+          span.date__status[
+            ng-class="{canceled: isCanceled(event), published: isPublished(event), draft: isDraft(event), hide: (isDraft(event) && isStudent(course))}"]
             | {{translatedStatus(event)}}

--- a/app/assets/templates/courses/tabs/events.html.slim
+++ b/app/assets/templates/courses/tabs/events.html.slim
@@ -14,7 +14,8 @@
     a.button.secondary.tiny.transparent.edit__in__journal.right ng-click="goToEvent(event)" ng-if="course.user_role == 'teacher'"
       | editar aula
     .date
-      span.date__status ng-class="{cancelled: event.formatted_status == 'canceled', draft: (event.formatted_status == 'empty') || (event.formatted_status == 'draft')}"
+      span.date__status[
+        ng-class="{canceled: isCanceled(event), published: isPublished(event), draft: isDraft(event), hide: (isPublished(event) && isStudent(course))}"]
         | {{translatedStatus(event)}}
       | {{event.start_at | date:'EEE, dd/MMM/yy'}}
       br


### PR DESCRIPTION
Connects to #830 
Connects to #842
Closes #850

I believe it would be a good idea for the API to not send drafted events for the student if we're not going to show them, but we can leave this for the future.

I stopped using `formatted_status` since we only care abour `draft`, `published` or `canceled` events. Did not removed because `formatted_status` `empty` and `happened` can still be used for things like blankslate.

@lunks @mrodrigues 
Ready for review.
