### PR TITLE
Use $templateCache to handle templates.

### DIFF
--- a/app/assets/javascripts/app/app.module.coffee
+++ b/app/assets/javascripts/app/app.module.coffee
@@ -16,4 +16,5 @@ angular
     'app.lessonPlan',
     'app.join',
     'app.profile',
-    'app.users']
+    'app.users',
+    'app.templates']

--- a/app/assets/javascripts/app/app.routes.coffee
+++ b/app/assets/javascripts/app/app.routes.coffee
@@ -11,83 +11,83 @@ Router = ($stateProvider,
     .state('courses',
       url: '/courses'
       controller: 'CoursesIndexCtrl as vm'
-      templateUrl: '<%= asset_path('app/courses/courses') %>'
+      templateUrl: 'courses/courses'
       resolve: { courses: CoursesResolver }
     )
     .state('courses.inactive',
       url: '/inactive'
-      templateUrl: '<%= asset_path('app/courses/courses-inactive') %>'
+      templateUrl: 'courses/courses-inactive'
     )
     .state('courses.search',
       url: '/search'
       controller: 'CourseSearchCtrl'
-      templateUrl: '<%= asset_path('app/join/course-join') %>'
+      templateUrl: 'join/course-join'
     )
     .state('courses.confirm_registration',
       url: '/:id/confirm_registration'
       controller: 'CourseConfirmRegistrationCtrl'
-      templateUrl: '<%= asset_path('app/join/course-confirm') %>'
+      templateUrl: 'join/course-confirm'
       resolve: { course: CourseRegistrationResolver }
     )
     .state('courses.show',
       url: '/:courseId'
       abstract: true
       controller: 'CourseCtrl'
-      templateUrl: '<%= asset_path('app/courses/course-detail') %>'
+      templateUrl: 'courses/course-detail'
       resolve: { course: CourseResolver }
     )
     .state('courses.show.calendar',
       url: '/calendar?month'
       controller: 'CalendarCtrl'
-      templateUrl: '<%= asset_path('app/courses/calendar/calendar') %>'
+      templateUrl: 'courses/calendar/calendar'
       resolve: { course: CourseResolver }
     )
     .state('courses.show.events',
       url: '/events?until'
       controller: 'CourseEventsCtrl'
-      templateUrl: '<%= asset_path('app/courses/events/events') %>'
+      templateUrl: 'courses/events/events'
       resolve: { pagination: EventsPaginationResolver }
     )
     .state('courses.show.calendar.schedule',
       url: '/schedule'
       controller: 'ScheduleCtrl'
-      templateUrl: '<%= asset_path('app/courses/schedule/schedule') %>'
+      templateUrl: 'courses/schedule/schedule'
     )
     .state('courses.show.members',
       url: '/members'
       controller: 'CourseMembersCtrl as vm'
-      templateUrl: '<%= asset_path('app/courses/members/members') %>'
+      templateUrl: 'courses/members/members'
       resolve: { course: CourseResolver }
     )
     .state('courses.show.event',
       url: '/events/:startAt'
       views:
           '@':
-            templateUrl: '<%= asset_path('app/lesson-plan/lesson-plan-edit') %>'
+            templateUrl: 'lesson-plan/lesson-plan-edit'
             controller: 'EventCtrl'
       resolve: { event: EventResolver }
     )
     .state('events.show',
       url: '/:startAt?courseId'
       controller: 'EventCtrl'
-      templateUrl: '<%= asset_path('app/lesson-plan/lesson-plan-edit') %>'
+      templateUrl: 'lesson-plan/lesson-plan-edit'
       resolve: { event: EventResolver }
     )
     .state('medias',
       url: '/catalog'
       controller: 'MediasIndexCtrl'
-      templateUrl: '<%= asset_path('app/catalog/catalog') %>'
+      templateUrl: 'catalog/catalog'
       resolve: { searchResult: MediasResolver }
     )
     .state('profile',
       url: '/profile/edit'
       controller: 'ProfileCtrl'
-      templateUrl: '<%= asset_path('app/profile/profile') %>'
+      templateUrl: 'profile/profile'
     )
     .state('profile.change_password',
       url: '/profile/password/edit'
       controller: 'PasswordCtrl'
-      templateUrl: '<%= asset_path('app/profile/password') %>'
+      templateUrl: 'profile/password'
     )
 
 Router.$inject = [

--- a/app/assets/javascripts/app/core/components/course-card.directive.coffee
+++ b/app/assets/javascripts/app/core/components/course-card.directive.coffee
@@ -1,5 +1,5 @@
 courseCard = ->
-  templateUrl: '<%= asset_path("app/core/components/course-card.directive.html") %>'
+  templateUrl: 'core/components/course-card.directive'
   restrict: 'E'
 
 angular

--- a/app/assets/javascripts/app/core/components/course-link.directive.coffee
+++ b/app/assets/javascripts/app/core/components/course-link.directive.coffee
@@ -7,7 +7,7 @@ courseLink = ->
 
   controller: courseLinkCtrl
   controllerAs: 'vm'
-  templateUrl: '<%= asset_path("app/core/components/course-link.directive.html") %>'
+  templateUrl: 'core/components/course-link.directive'
   scope:
     course: '='
     page: '@?'

--- a/app/assets/javascripts/app/core/components/search-input.directive.coffee
+++ b/app/assets/javascripts/app/core/components/search-input.directive.coffee
@@ -12,7 +12,7 @@ searchInput = ->
 
   link: link
   restrict: 'E'
-  templateUrl: '<%= asset_path("app/core/components/search-input.directive.html") %>'
+  templateUrl: 'core/components/search-input.directive'
   replace: true
   scope:
     performSearch: '&'

--- a/app/assets/javascripts/app/core/config.module.coffee
+++ b/app/assets/javascripts/app/core/config.module.coffee
@@ -21,12 +21,12 @@ angular
 #WIP
 core = angular.module('app.core')
 
-core.config(["railsSerializerProvider", (railsSerializerProvider)->
+core.config(["railsSerializerProvider", (railsSerializerProvider) ->
   railsSerializerProvider.underscore(angular.identity).camelize(angular.identity)
 ])
 
 core.value('cgBusyDefaults',
-  templateUrl: '<%= asset_path('app/core/components/loading.html') %>',
+  templateUrl: 'core/components/loading',
   minDuration: 500,
   wrapperClass: 'cg-busy cg-busy-animation ng-animate'
 )

--- a/app/assets/javascripts/app/courses/course-form.directive.coffee
+++ b/app/assets/javascripts/app/courses/course-form.directive.coffee
@@ -15,7 +15,7 @@ courseFormCtrl.$inject = [
   '$state']
 
 courseForm = ->
-  templateUrl: '<%= asset_path("app/courses/course-form.directive.html") %>'
+  templateUrl: 'courses/course-form.directive'
   controller: courseFormCtrl
   controllerAs: 'vm'
   bindToController: true

--- a/app/assets/javascripts/app/courses/course.controller.coffee
+++ b/app/assets/javascripts/app/courses/course.controller.coffee
@@ -1,9 +1,9 @@
-CourseCtrl = ($scope, ModalFactory, course)->
+CourseCtrl = ($scope, ModalFactory, course) ->
   $scope.course = course
 
   $scope.openEditCourseForm = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/course-edit.html') %>'
+      templateUrl: 'courses/course-edit'
       controller: 'EditCourseCtrl'
       controllerAs: 'vm'
       bindToController: true
@@ -13,7 +13,7 @@ CourseCtrl = ($scope, ModalFactory, course)->
 
   $scope.openNotification = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/notify/notify-members.html') %>'
+      templateUrl: 'courses/notify/notify-members'
       controller: 'NotificationCtrl'
       controllerAs: 'vm'
       bindToController: true

--- a/app/assets/javascripts/app/courses/courses.controller.coffee
+++ b/app/assets/javascripts/app/courses/courses.controller.coffee
@@ -6,7 +6,7 @@ CoursesIndexCtrl = ($location, $filter, ModalFactory, Utils, courses) ->
 
   @openNewCourseForm = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/course-new.html') %>'
+      templateUrl: 'courses/course-new'
       controller: 'NewCourseCtrl'
       controllerAs: 'vm'
       bindToController: true

--- a/app/assets/javascripts/app/courses/events/event-status.coffee
+++ b/app/assets/javascripts/app/courses/events/event-status.coffee
@@ -33,7 +33,7 @@ eventStatusCtrl.$inject = ['$scope']
 
 eventStatus = ->
   restrict: 'E'
-  templateUrl: '<%= asset_path("app/courses/events/event-status") %>'
+  templateUrl: 'courses/events/event-status'
   controller: eventStatusCtrl
   controllerAs: 'vm'
   scope:

--- a/app/assets/javascripts/app/courses/members/course.members.controller.coffee
+++ b/app/assets/javascripts/app/courses/members/course.members.controller.coffee
@@ -19,7 +19,7 @@ CourseMembersCtrl = (course, ModalFactory) ->
 
   @openInviteMembers = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/invite/invite-members') %>'
+      templateUrl: 'courses/invite/invite-members'
       controller: 'InviteMembersController'
       controllerAs: 'vm'
       class: 'full invite__members'

--- a/app/assets/javascripts/app/courses/members/invite.members.controller.coffee
+++ b/app/assets/javascripts/app/courses/members/invite.members.controller.coffee
@@ -2,7 +2,7 @@ InviteMembersController = (ModalFactory, course) ->
   @course = course
   @openInviteMembersFullscreen = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/invite/invite-fullscreen') %>'
+      templateUrl: 'courses/invite/invite-fullscreen'
       controller: 'InviteMembersFullscreenController'
       controllerAs: 'vm'
       class: 'full invite__members__fullscreen'

--- a/app/assets/javascripts/app/courses/schedule/schedule.controller.coffee
+++ b/app/assets/javascripts/app/courses/schedule/schedule.controller.coffee
@@ -13,7 +13,7 @@ ScheduleCtrl = (
 
   $scope.transferWeeklySchedule = (weeklySchedule) ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/schedule/schedule-transfer') %>',
+      templateUrl: 'courses/schedule/schedule-transfer',
       controller: 'TransferWeeklyScheduleCtrl'
       resolve:
         weeklySchedule: -> angular.copy(weeklySchedule)
@@ -21,7 +21,7 @@ ScheduleCtrl = (
 
   $scope.newWeeklySchedule = ->
     new ModalFactory
-      templateUrl: '<%= asset_path('app/courses/schedule/schedule-new') %>',
+      templateUrl: 'courses/schedule/schedule-new',
       controller: 'NewWeeklyScheduleCtrl'
       resolve:
         weeklySchedule: -> angular.copy(new WeeklySchedule(course_id: $scope.course.uuid))

--- a/app/assets/javascripts/app/lesson-plan/new-topic/preview.directive.coffee
+++ b/app/assets/javascripts/app/lesson-plan/new-topic/preview.directive.coffee
@@ -8,7 +8,7 @@ previewCtrl.$inject = ['$scope']
 preview = ->
   restrict: 'E'
   controller: previewCtrl
-  templateUrl: '<%= asset_path('app/core/components/preview.html') %>'
+  templateUrl: 'core/components/preview'
   scope:
     item: '='
     removable: '='

--- a/app/assets/javascripts/app/templates.js.erb
+++ b/app/assets/javascripts/app/templates.js.erb
@@ -1,0 +1,12 @@
+angular.module('app.templates', []).run([ '$templateCache', function($templateCache) {
+  <%
+    app_root  = File.expand_path('../', __FILE__)
+    templates = File.join(app_root, %w{** *.slim})
+    Dir.glob(templates).each do |f|
+      depend_on(f)
+      key = f.gsub(%r(^#{app_root}/),'').gsub(/\.slim/, '')
+      content = environment["app/#{key}.html"].to_s
+  %>
+    $templateCache.put("<%= key %>", "<%= escape_javascript(content) %>" );
+<% end %>
+}]);


### PR DESCRIPTION
This allows us to drop the `erb` extension and make it easier to
reference a template.
