### PR TITLE
Remove ng-animate scoping.

### DIFF
--- a/app/assets/javascripts/app/core/config.module.coffee
+++ b/app/assets/javascripts/app/core/config.module.coffee
@@ -27,13 +27,8 @@ core.config(["railsSerializerProvider", (railsSerializerProvider) ->
 
 core.value('cgBusyDefaults',
   templateUrl: 'core/components/loading',
-  minDuration: 500,
-  wrapperClass: 'cg-busy cg-busy-animation ng-animate'
+  wrapperClass: 'cg-busy cg-busy-animation'
 )
-
-core.config ['$animateProvider', ($animateProvider) ->
-  $animateProvider.classNameFilter(/ng-animate/)
-]
 
 core.run ['amMoment', (amMoment) ->
   amMoment.changeLocale('pt-br')


### PR DESCRIPTION
@ltartari Take a look at this when you've got some free time. This allows us to use ng-animate in the app more easily.
Removing this loading delay also seems to help the overall preceived speed on the app.
