### PR TITLE
Show a different message for canceled empty, canceled with topics and…

### DIFF
--- a/app/assets/javascripts/app/courses/events/events.slim
+++ b/app/assets/javascripts/app/courses/events/events.slim
@@ -63,8 +63,18 @@
                 ui-sref="^.event({ startAt: event.start_at })"]
                 | abrir no diário
           .event__content ng-class="'event__status__' + event.status"
-            .event__item.event__empty ng-if="event.topics.length == 0"
+            .event__item.event__empty ng-if="event.topics.length == 0 && event.status != 'canceled'"
               | Nenhum conteúdo disponível para esse dia.
+            .event__item.event__canceled__with__topics ng-if="event.topics.length && event.status == 'canceled'"
+              p.message__warning
+                strong>
+                  | Atenção:
+                | Essa aula foi cancelada e possui conteúdos. Informe-se quando eles serão retomados.
+            .event__item.event__canceled__with__no__topics ng-if="event.topics.length == 0 && event.status == 'canceled'"
+              p.message__warning
+                strong>
+                  | Atenção:
+                | Essa aula foi cancelada.
             .event__item[
               ng-repeat="topic in event.topics"]
               img.event__item__image[

--- a/app/assets/stylesheets/app/components/_messages.scss
+++ b/app/assets/stylesheets/app/components/_messages.scss
@@ -27,4 +27,10 @@
       $radius: 0
     );
   }
+
+  &__warning {
+    color: $red-color;
+    text-align: center;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
Closes #797 
Connects to #797 

Ready for review.

@mrodrigues @lunks 

Exemple below shows message for canceled events with and without topics.
![image](https://cloud.githubusercontent.com/assets/114248/10768852/38eb23f8-7cca-11e5-81db-70f35734572c.png)
