### PR TITLE
Reduce margins for mark as read button on system notifications

### DIFF
--- a/app/assets/stylesheets/app/components/_notifications.scss
+++ b/app/assets/stylesheets/app/components/_notifications.scss
@@ -42,13 +42,13 @@
 
   &__clear,
   &__empty {
-    padding: 2rem;
     text-align: center;
   }
 
   &__empty {
     color: $medium-grey-color;
     font-size: .875rem;
+    padding: 2rem;
   }
 
   &__count {


### PR DESCRIPTION
Ready for review @mrodrigues 

This is how it looks now:
![image](https://cloud.githubusercontent.com/assets/114248/11073380/89b055f8-87d1-11e5-9c3c-c1263f42d5e6.png)

Closes #1295.
